### PR TITLE
Update for building with Xcode 11

### DIFF
--- a/marzipanify/main.m
+++ b/marzipanify/main.m
@@ -336,7 +336,7 @@ NSArray *modifyMachHeaderAndReturnNSArrayOfLoadedDylibs(NSString *binaryPath)
 		else if(command->cmd == LC_BUILD_VERSION)
 		{
 			struct build_version_command ucmd = *(struct build_version_command*)imageHeaderPtr;
-			ucmd.platform = PLATFORM_IOSMAC;
+			ucmd.platform = PLATFORM_MACCATALYST;
 			ucmd.minos = 12<<16|0<<8|0;
 			ucmd.sdk = 10<<16|14<<8|0;
 			


### PR DESCRIPTION
replaces the "PLATFORM_IOSMAC" symbol with "PLATFORM_MACCATALYST".